### PR TITLE
docs(contributing): specify the right repository name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to translate-async-loader
+# Contributing to web-universe-components
 
 This project accepts contributions. In order to contribute, you should
 pay attention to a few things:
@@ -17,8 +17,8 @@ The contributions should be submitted through Github Pull Requests.
 
 # Licensing for new files
 
-translate-async-loader is licensed under a BSD-3-Clause license. Anything
-contributed to translate-async-loader must be released under this license.
+web-universe-components is licensed under a BSD-3-Clause license. Anything
+contributed to web-universe-components must be released under this license.
 
 When introducing a new file into the project, please make sure it has a
 copyright header making clear under which license it's being released.


### PR DESCRIPTION
Due to a wrong copy/paste, I've just replaced `translate-async-loader` occurrences to `web-universe-components`.