### PR TITLE
build(deps): upgrade ng-ovh-http to v4.0.1-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "stylelint-config-standard": "^18.2.0"
   },
   "peerDependencies": {
+    "@ovh-ux/ng-ovh-http": "git+https://github.com/ovh-ux/ovh-angular-http.git#minor-updates",
     "@ovh-ux/ovh-utils-angular": "^14.0.2",
     "@ovh-ux/translate-async-loader": "^1.0.7",
     "@uirouter/angularjs": "^1.0.0",
@@ -66,7 +67,6 @@
     "justgage": "^1.2.2",
     "lodash": "^3.10.1",
     "moment": "^2.16.0",
-    "ovh-angular-http": "^3.0.1",
     "ovh-angular-swimming-poll": "^3.0.1",
     "ovh-api-services": "^3.24.0",
     "punycode": "^1.2.4"

--- a/src/alldom/index.js
+++ b/src/alldom/index.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import 'ovh-angular-http';
+import '@ovh-ux/ng-ovh-http';
 
 import WucAllDom from './domain-alldom.service';
 
@@ -7,7 +7,7 @@ const moduleName = 'wucAllDom';
 
 angular
   .module(moduleName, [
-    'ovh-angular-http',
+    'ngOvhHttp',
   ])
   .service('WucAllDom', WucAllDom);
 

--- a/src/email-domain/index.js
+++ b/src/email-domain/index.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import 'ovh-angular-http';
+import '@ovh-ux/ng-ovh-http';
 import 'ovh-angular-swimming-poll';
 
 import WucEmails from './email-domain.service';
@@ -8,7 +8,7 @@ const moduleName = 'wucEmailDomain';
 
 angular
   .module(moduleName, [
-    'ovh-angular-http',
+    'ngOvhHttp',
     'ovh-angular-swimming-poll',
   ])
   .service('WucEmails', WucEmails);

--- a/yarn.lock
+++ b/yarn.lock
@@ -912,14 +912,12 @@
     rollup-pluginutils "^2.3.3"
     slash "^2.0.0"
 
-"@ovh-ux/ovh-utils-angular@^14.0.2":
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/ovh-utils-angular/-/ovh-utils-angular-14.0.2.tgz#837fbfcd093287971aa6d0733a1bbad0e008e8e7"
-  integrity sha512-mJPo16TErF948lbvS6JBeue9HjqN29C6ub5Hl++61CuSYTDeNTHIsXELC4TW1QiNP7otGZm93jf2Fb0ZMsjTbg==
+"@ovh-ux/ng-ovh-http@git+https://github.com/ovh-ux/ovh-angular-http.git#minor-updates":
+  version "4.0.1-alpha.0"
+  resolved "git+https://github.com/ovh-ux/ovh-angular-http.git#c50ff86578e74fcb99c01a64b67426d8419a0969"
   dependencies:
-    "@ovh-ux/translate-async-loader" "^1.0.4"
-    filesize "^3.6.1"
-    lodash "^4.17.11"
+    lodash "~4.17.11"
+    urijs "^1.19.1"
 
 "@ovh-ux/rollup-plugin-less-tilde-importer@^1.0.0-beta.0":
   version "1.0.0-beta.0"
@@ -928,11 +926,6 @@
   dependencies:
     magic-string "^0.25.1"
     rollup-pluginutils "^2.3.3"
-
-"@ovh-ux/translate-async-loader@^1.0.4":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@ovh-ux/translate-async-loader/-/translate-async-loader-1.0.8.tgz#7cbdc3dfed1042f511206ff6bb9f14c33b8406ba"
-  integrity sha512-8yEhPeRTSxtEO9ODXRYZw6pzRQiV5ULCTi8mIzt39m/b9N2TcIF4ILTPsaa8xpE4npHKa/iYgL9z0HJUFi2LGQ==
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -2708,11 +2701,6 @@ filename-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
   integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
 
-filesize@^3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
-  integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
-
 fill-range@^2.1.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
@@ -4400,7 +4388,7 @@ lodash@4.17.10:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10, lodash@~4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -7433,6 +7421,11 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
+
+urijs@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.1.tgz#5b0ff530c0cbde8386f6342235ba5ca6e995d25a"
+  integrity sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## ⬆️ Upgrade `ng-ovh-http` to `v4.0.1-alpha.0`

⚠️ Please do not merge ⚠️ 

### Description of the Change

6547756 — build(deps): upgrade ng-ovh-http to v4.0.1-alpha.0

ref: OM-251

### Requirements

- [ ] A new `ng-ovh-http` release